### PR TITLE
Update nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1698420672,
-        "narHash": "sha256-/TdeHMPRjjdJub7p7+w55vyABrsJlt5QkznPYy55vKA=",
+        "lastModified": 1718727675,
+        "narHash": "sha256-uFsCwWYI2pUpt0awahSBorDUrUfBhaAiyz+BPTS2MHk=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "aeb58d5e8faead8980a807c840232697982d47b9",
+        "rev": "941ce6dc38762a7cfb90b5add223d584feed299b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698336494,
-        "narHash": "sha256-sO72WDBKyijYD1GcKPlGsycKbMBiTJMBCnmOxLAs880=",
+        "lastModified": 1713805509,
+        "narHash": "sha256-YgSEan4CcrjivCNO5ZNzhg7/8ViLkZ4CB/GrGBVSudo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "808c0d8c53c7ae50f82aca8e7df263225cf235bf",
+        "rev": "1e1dc66fe68972a76679644a5577828b6a7e8be4",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1709703039,
-        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
+        "lastModified": 1719506693,
+        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
+        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
             };
           in
           with pkgs; [
-            zig
+            zig_0_11
             zls
             nickel
             nls

--- a/src/platforms/testing/tests/conditionals/is_key_pressed.ncl
+++ b/src/platforms/testing/tests/conditionals/is_key_pressed.ncl
@@ -1,4 +1,4 @@
-let { imports, step, event, codes, report, toKeyMap, .. } = import "base.ncl" in
+let { imports, step, codes, report, toKeyMap, .. } = import "base.ncl" in
 let { lit, switch, case, key-press, kc, is-key-pressed, not, or, and, .. } = imports.lib in
 
 let md = codes.mod in

--- a/src/platforms/testing/tests/conditionals/is_pressed.ncl
+++ b/src/platforms/testing/tests/conditionals/is_pressed.ncl
@@ -1,4 +1,4 @@
-let { imports, step, event, codes, report, toKeyMap, .. } = import "base.ncl" in
+let { imports, step, codes, report, toKeyMap, .. } = import "base.ncl" in
 let { lit, switch, case, key-press, kc, is-pressed, mod, .. } = imports.lib in
 
 let md = codes.mod in

--- a/src/platforms/testing/tests/conditionals/layers.ncl
+++ b/src/platforms/testing/tests/conditionals/layers.ncl
@@ -1,4 +1,4 @@
-let { imports, step, event, codes, report, toKeyMap, .. } = import "base.ncl" in
+let { imports, step, codes, report, toKeyMap, .. } = import "base.ncl" in
 let { lit, switch, case, key-press, kc, is-key-code-pressed, and, .. } = imports.lib in
 
 let md = codes.mod in

--- a/src/platforms/testing/tests/conditionals/mod_morph.ncl
+++ b/src/platforms/testing/tests/conditionals/mod_morph.ncl
@@ -1,4 +1,4 @@
-let { imports, step, event, codes, report, toKeyMap, .. } = import "base.ncl" in
+let { imports, step, codes, report, toKeyMap, .. } = import "base.ncl" in
 let { lit, switch, case, key-press, kc, is-key-code-pressed, or, mod, mod-weak, mod-weak-anti, .. } = imports.lib in
 
 let md = codes.mod in

--- a/src/platforms/testing/tests/key_press/anti_mods.ncl
+++ b/src/platforms/testing/tests/key_press/anti_mods.ncl
@@ -1,4 +1,4 @@
-let { imports, step, event, codes, report, toKeyMap, .. } = import "base.ncl" in
+let { imports, step, codes, report, toKeyMap, .. } = import "base.ncl" in
 let { lit, key-press, kc, mod, mod-anti, mod-weak-anti, .. } = imports.lib in
 
 let md = codes.mod in

--- a/src/platforms/testing/tests/key_press/mods.ncl
+++ b/src/platforms/testing/tests/key_press/mods.ncl
@@ -1,4 +1,4 @@
-let { imports, step, event, codes, report, .. } = import "base.ncl" in
+let { imports, step, codes, report, .. } = import "base.ncl" in
 let { lit, key-press, kc, mod, .. } = imports.lib in
 
 let md = codes.mod in

--- a/src/platforms/testing/tests/key_press/weak_mods.ncl
+++ b/src/platforms/testing/tests/key_press/weak_mods.ncl
@@ -1,4 +1,4 @@
-let { imports, step, event, codes, report, toKeyMap, .. } = import "base.ncl" in
+let { imports, step, codes, report, toKeyMap, .. } = import "base.ncl" in
 let { lit, key-press, kc, mod, mod-weak, .. } = imports.lib in
 
 let md = codes.mod in

--- a/src/platforms/testing/tests/key_toggle/simple.ncl
+++ b/src/platforms/testing/tests/key_toggle/simple.ncl
@@ -1,4 +1,4 @@
-let { imports, step, event, codes, report, toKeyMap, .. } = import "base.ncl" in
+let { imports, step, codes, report, toKeyMap, .. } = import "base.ncl" in
 let { lit, key-press, key-toggle, kc, mod, mod-anti, mod-weak-anti, .. } = imports.lib in
 
 let md = codes.mod in


### PR DESCRIPTION
This PR updates the `flake.lock`, with a couple of changes required to enable this.

On `main`, `nickel` is `1.4`, `zig` is `0.11`.

Nickel's 1.5 and 1.7 releases have some nice UX improvements.

Updating the flake with `nix flake update` provides a newer nickel with these features.

Some of the destructuring/pattern matching code needed to be updated for Nickel 1.7.

The `zig build` commands didn't work with the updated `zig` (`0.13`), and nixpkgs has `zig_0_11`, so I updated the devShell to use that.